### PR TITLE
Allow multiple recipients to be listed in the 'to' field

### DIFF
--- a/Serilog.Sinks.SendGridEmail.csproj
+++ b/Serilog.Sinks.SendGridEmail.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-      <TargetFrameworks>net45;net47;netstandard2.0;netstandard2.1</TargetFrameworks>
+      <TargetFrameworks>net47;netstandard2.0;netstandard2.1</TargetFrameworks>
       <PackageVersion>2.1.0</PackageVersion>
       <AssemblyVersion>2.1.0.0</AssemblyVersion>
       <Version>2.1.0</Version>

--- a/Sinks/SendGridEmail/SendGridEmailSink.cs
+++ b/Sinks/SendGridEmail/SendGridEmailSink.cs
@@ -59,8 +59,17 @@ namespace Serilog.Sinks.Email
             _subjectLineFormatter.Format(eventsSet.OrderByDescending(e => e.Level).First(), subject);
 
             var from = new EmailAddress(_connectionInfo.FromEmail, _connectionInfo.FromName);
-            var to = new EmailAddress(_connectionInfo.ToEmail);
-            var msg = MailHelper.CreateSingleEmail(from, to, _connectionInfo.EmailSubject, payload.ToString(), payload.ToString());
+
+            char[] delimiters = new[] { ',', ';', ' ' };
+            var splitEmails = _connectionInfo.ToEmail.Trim().ToLower().Split(delimiters, StringSplitOptions.RemoveEmptyEntries);
+
+            var to = new List<EmailAddress> { };
+            foreach (var splitEmail in splitEmails)
+            {
+                to.Add(new EmailAddress(splitEmail));
+            }
+
+            var msg = MailHelper.CreateSingleEmailToMultipleRecipients(from, to, _connectionInfo.EmailSubject, payload.ToString(), payload.ToString());
 
             await _client.SendEmailAsync(msg);
 		}


### PR DESCRIPTION
Splitting the 'to' string and using SingleEmailMultipleRecipients SendGrid API, still enables only one recipient to be specified.